### PR TITLE
Witness start

### DIFF
--- a/features/support/witness_steps.js
+++ b/features/support/witness_steps.js
@@ -1,0 +1,24 @@
+const { Given, When, Then } = require("cucumber");
+const { expect } = require("chai");
+
+When(/the user says witness me/, function() {
+  const { bot, user, db, event } = this.mocks;
+  const {
+    witnessMeCommand: commandClass
+  } = require(`../../src/commands/witnessMe`);
+
+  return commandClass.handle({
+    bot,
+    user,
+    event,
+    db,
+    userId: this.given.userId,
+    channelId: this.given.channelId,
+    guildId: this.given.guildId,
+    message: `witness me`
+  });
+});
+
+Then(/the watched users for {(.*)} contains {(.*)}/, function(guild, user) {
+  expect(this.when.guild[guild]).to.include(user);
+});

--- a/features/witness.feature
+++ b/features/witness.feature
@@ -1,0 +1,7 @@
+Feature: Users can opt into having their games be watched and added
+
+    Scenario: Users can start being watched
+        Given a user {user1}
+        And a guild {guild1}
+        When the user says witness me
+        Then the watched users for {guild1} contains {user1}

--- a/src/bot.js
+++ b/src/bot.js
@@ -7,6 +7,7 @@ const { whoPlaysCommand } = require("./commands/whoPlays");
 const { iPlayCommand } = require("./commands/iPlay");
 const { gamesCommand } = require("./commands/games");
 const { whatsNewCommand } = require("./commands/whatsNew");
+const { witnessMeCommand } = require("./commands/witnessMe");
 const { extractGuildId } = require("./discordUtils");
 
 const discordAuth =
@@ -42,7 +43,8 @@ const allCommands = [
   whoPlaysCommand,
   iPlayCommand,
   gamesCommand,
-  whatsNewCommand
+  whatsNewCommand,
+  witnessMeCommand
 ];
 
 const playBotId = "456628305911873536";
@@ -103,13 +105,8 @@ bot.on("message", (user, userID, channelID, originalMessage, event) => {
   }
 });
 
-// bot.on("presence", (user, userID, status, game, event) => {
-//   if (!isTestUser(userID)) {
-//     return;
-//   }
-
-//   const gameName = game ? game.name : undefined;
-//   logger.debug(`${user} is playing ${gameName}`);
-//   // db.doc(`channels/${`)
-//   // update(db)()
-// });
+bot.on("presence", (user, userID, status, game, event) => {
+  if (!isTestUser(userID)) {
+    return;
+  }
+});

--- a/src/commands/witnessMe.js
+++ b/src/commands/witnessMe.js
@@ -1,0 +1,38 @@
+const { Command } = require("./command");
+const { update } = require("../firestoreUtils");
+
+const ALREADY_WATCHED = Symbol("ALREAD_WATCHED");
+
+const witnessMeCommand = new Command({
+  name: "Witness Me",
+  command: /witness me/gi,
+  example: "witness me",
+  test: false,
+  handler: ({ bot, channelId, userId, db, guildId }) => {
+    const watchedUsers = db.doc(`guilds/${guildId}`);
+    const updateWatched = update(db)(watchedUsers);
+    const updatePromise = updateWatched(
+      (
+        oldWatched = {
+          watched_users: []
+        }
+      ) => {
+        if (oldWatched.watched_users.includes(userId)) {
+          throw ALREADY_WATCHED;
+        }
+        return {
+          ...oldWatched,
+          watched_users: [...oldWatched.watched_users, userId]
+        };
+      }
+    );
+    return updatePromise.then(() => {
+      bot.sendMessage({
+        to: channelId,
+        message: `<@${userId}> we ride eternal! Shiny and chrome!`
+      });
+    });
+  }
+});
+
+module.exports = { witnessMeCommand, ALREADY_WATCHED };


### PR DESCRIPTION
Allow users to say `@play-bot witness me` to cause play bot to add them to a list of watched users. This will be used with the `presence` event to decide if we should automatically track the things they play.